### PR TITLE
Allow use of monads via full name qualification w/o importing them

### DIFF
--- a/src/com/mindrocks/monads/Monad.hx
+++ b/src/com/mindrocks/monads/Monad.hx
@@ -101,7 +101,15 @@ class Monad {
       optimize = genOptimize;
       
       
-    var monadRef = EConst(#if haxe3 CIdent #else CType #end(monadTypeName));
+    var monadRef = 
+      #if haxe3
+      Lambda.fold(monadTypeName.split("."), function(a, b) {
+        return b != null ? {expr:EField(b, a), pos:b.pos} : macro $i{a};
+      }, null).expr;
+      #else
+      EConst(CType(monadTypeName))
+      #end
+
     var position : Position = context.currentPos();
     function mk(e : ExprDef) return { pos : position, expr : e };
 


### PR DESCRIPTION
This is to support some custom monads I've made; it might make sense to update the Prelude monads as well (e.g., specify the full package name in OptionM.dO)
